### PR TITLE
Update docs with macOS build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Codex
-OpenAI Codex
+# Life Calculator App
+
+This repository contains the web-based Life Expectancy Calculator along with minimal SwiftUI examples for iOS and macOS. The native apps simply load the web interface using `WKWebView` so the HTML, CSS and JavaScript are bundled inside the application.
+
+## Directory Overview
+
+- `index.html`, `style.css`, `app.js` – the stand‑alone web version of the calculator
+- `ios/` – SwiftUI sample for iOS
+- `macos/` – SwiftUI sample for macOS
+
+The iOS and macOS folders do not include an Xcode project. Instead, create a new Xcode project and add these files so the resources are copied into the app bundle.
+
+## Building the macOS App
+
+See [macos/README.md](macos/README.md) for detailed steps on creating the project and bundling the resources in Xcode.

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,5 +1,16 @@
 # macOS App
 
-This directory contains a minimal SwiftUI macOS application that loads the life calculator web app using `WKWebView`. The `WebResources` folder contains copies of the HTML, CSS and JavaScript files.
+This directory contains a minimal SwiftUI application that embeds the Life Expectancy Calculator website in a `WKWebView`.
 
-Open the folder in Xcode and create a new macOS project. Add these files and include the resources in the application bundle.
+## How to create the Xcode project
+
+1. Open Xcode and choose **File > New > Project…**.
+2. Select **App** under the macOS tab and click **Next**.
+3. Enter a product name, set **Interface** to **SwiftUI**, and choose **None** for the **Storage** option.
+4. Finish creating the project in a convenient location.
+5. In the project navigator, right‑click the top-level group and select **Add Files to "[Your Project]"…**.
+6. Choose the entire `macos` folder from this repository. Enable **Copy items if needed** and select **Create Groups** when prompted.
+7. Ensure the HTML, CSS and JavaScript files inside `WebResources` are listed under **Copy Bundle Resources** in the target's *Build Phases*.
+8. Build and run. `ContentView` loads `index.html` from the bundle so the calculator appears in the app window.
+
+These steps bundle the web resources with your macOS app without modifying the Swift code.


### PR DESCRIPTION
## Summary
- add repository overview and cross-platform instructions
- expand macOS README with step-by-step Xcode guidance

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684fb58c505483218a50687c3baaa97d